### PR TITLE
Pyproject and annotations updates

### DIFF
--- a/.github/workflows/bazel_test_mac.yml
+++ b/.github/workflows/bazel_test_mac.yml
@@ -16,6 +16,14 @@ jobs:
       # the rest of the steps
       - uses: actions/checkout@v3
 
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Python version check
+        run: PYTHON=python3 python --version
+
         # test
       - name: Build the code
         run: bazel build //...

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # clODE - an OpenCL based tool for solving ordinary differential equations (ODEs)
 
 [![Python](https://img.shields.io/pypi/pyversions/clode.svg)](https://badge.fury.io/py/clode)
-[![PyPI](https://badge.fury.io/py/clode.svg)](https://badge.fury.io/py/tensorflow)
+[![PyPI](https://badge.fury.io/py/clode.svg)](https://badge.fury.io/py/clode)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patrickfletcher/clODE/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patrickfletcher/clODE)
 ![Windows](https://github.com/patrickfletcher/clODE/actions/workflows/bazel_build_windows.yml/badge.svg)
 ![Mac](https://github.com/patrickfletcher/clODE/actions/workflows/bazel_test_mac.yml/badge.svg) 

--- a/clode/python/__init__.py
+++ b/clode/python/__init__.py
@@ -16,4 +16,4 @@ from .stepper import Stepper
 from .trajectory import CLODETrajectory
 from .xpp_parser import convert_xpp_file, format_opencl_rhs, read_ode_parameters
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"

--- a/clode/python/features.py
+++ b/clode/python/features.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Optional, Tuple
 
 import numpy as np
@@ -243,7 +245,13 @@ class CLODEFeatures:
         self._observer_type = observer
         self._features.build_cl()
 
-    def initialize(self, x0: np.array, parameters: np.array, tspan:Tuple[float, float]|None = None, seed: int|None = None):
+    def initialize(
+        self,
+        x0: np.array,
+        parameters: np.array,
+        tspan: Tuple[float, float] | None = None,
+        seed: int | None = None,
+    ):
 
         if len(x0.shape) != 2:
             raise ValueError("Must provide rows of initial variables")
@@ -262,9 +270,9 @@ class CLODEFeatures:
                 f"Length of parameters vector {parameters.shape[1]}"
                 f" does not match number of parameters {len(self.pars)}"
             )
-        
+
         if tspan is not None:
-            self.tspan=tspan
+            self.tspan = tspan
 
         self._features.initialize(
             self.tspan,
@@ -275,12 +283,12 @@ class CLODEFeatures:
         )
         self.seed_rng(seed)
 
-    def seed_rng(self, seed: int|None = None):
+    def seed_rng(self, seed: int | None = None):
         if seed is not None:
             self._features.seed_rng(seed)
         else:
             self._features.seed_rng()
-        
+
     def set_tspan(self, new_tspan: Tuple[float, float]):
         self.tspan = new_tspan
         self._features.set_tspan(new_tspan)
@@ -289,17 +297,17 @@ class CLODEFeatures:
         self._features.set_problem_data(
             x0.transpose().flatten(),
             parameters.transpose().flatten(),
-            )
-        
+        )
+
     def set_x0(self, x0: np.array):
         self._features.set_x0(
             x0.transpose().flatten(),
-            )
-        
+        )
+
     def set_parameters(self, parameters: np.array):
         self._features.set_pars(
             parameters.transpose().flatten(),
-            )
+        )
 
     def transient(self, update_x0: bool = True):
         self._features.transient()

--- a/clode/python/observer.py
+++ b/clode/python/observer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 
 import numpy as np

--- a/clode/python/problem_info.py
+++ b/clode/python/problem_info.py
@@ -1,12 +1,20 @@
-from .runtime import get_cpp
+from __future__ import annotations
+
 from typing import List
+
+from .runtime import get_cpp
 
 _clode = get_cpp()
 
 
 class ProblemInfo:
     def __init__(
-        self, src_file: str, vars: List[str], pars: List[str], aux: List[str], num_noise: int
+        self,
+        src_file: str,
+        vars: List[str],
+        pars: List[str],
+        aux: List[str],
+        num_noise: int,
     ):
         self._pi = _clode.problem_info(
             src_file, len(vars), len(pars), len(aux), num_noise, vars, pars, aux

--- a/clode/python/runtime.py
+++ b/clode/python/runtime.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from . import clode_cpp_wrapper as _clode  # type: ignore

--- a/clode/python/solver_params.py
+++ b/clode/python/solver_params.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import runtime
 
 _clode = runtime.get_cpp()

--- a/clode/python/stepper.py
+++ b/clode/python/stepper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 
 

--- a/clode/python/trajectory.py
+++ b/clode/python/trajectory.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Optional, Tuple
 
 import numpy as np
@@ -82,7 +84,13 @@ class CLODETrajectory:
         self.tspan = tspan
         self._trajectory.build_cl()
 
-    def initialize(self, x0: np.array, parameters: np.array, tspan:Tuple[float, float]|None = None, seed: int|None = None):
+    def initialize(
+        self,
+        x0: np.array,
+        parameters: np.array,
+        tspan: Tuple[float, float] | None = None,
+        seed: int | None = None,
+    ):
 
         if len(x0.shape) != 2:
             raise ValueError("Must provide rows of initial variables")
@@ -106,7 +114,7 @@ class CLODETrajectory:
         self._number_of_simulations = parameters.shape[0]
 
         if tspan is not None:
-            self.tspan=tspan
+            self.tspan = tspan
 
         self._trajectory.initialize(
             self.tspan,
@@ -115,13 +123,13 @@ class CLODETrajectory:
             self._sp,
         )
         self.seed_rng(seed)
-        
-    def seed_rng(self, seed: int|None = None):
+
+    def seed_rng(self, seed: int | None = None):
         if seed is not None:
             self._trajectory.seed_rng(seed)
         else:
             self._trajectory.seed_rng()
-        
+
     def set_tspan(self, tspan: Tuple[float, float]):
         self.tspan = tspan
         self._trajectory.set_tspan(tspan)
@@ -130,17 +138,17 @@ class CLODETrajectory:
         self._trajectory.set_problem_data(
             x0.transpose().flatten(),
             parameters.transpose().flatten(),
-            )
-        
+        )
+
     def set_x0(self, x0: np.array):
         self._trajectory.set_x0(
             x0.transpose().flatten(),
-            )
-        
+        )
+
     def set_parameters(self, parameters: np.array):
         self._trajectory.set_pars(
             parameters.transpose().flatten(),
-            )
+        )
 
     def transient(self, update_x0: bool = True):
         self._trajectory.transient()

--- a/clode/python/xpp_parser.py
+++ b/clode/python/xpp_parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: C++",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Mathematics",

--- a/test/test_vdp.py
+++ b/test/test_vdp.py
@@ -58,8 +58,8 @@ def vdp_dormand_prince(end: int, input_file: str = "test/van_der_pol_oscillator.
         period = periods[index, 0]
         expected_period = approximate_vdp_period(mu)
         rtol = 0.01
-        atol = 0.3
-        assert np.isclose(period, expected_period, rtol=rtol, atol=1), (
+        atol = 1
+        assert np.isclose(period, expected_period, rtol=rtol, atol=atol), (
             f"Period {period} not close to expected {expected_period}" + f"for mu {mu}"
         )
 


### PR DESCRIPTION
Modern annotations like `int | None` are not supported prior to Python 3.10. This commit adds future imports to support modern-style annotations.