### PR TITLE
Fix trajectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,156 @@ bazel-*
 .clwb
 
 
-*__pycache__
-venv
-clode.egg-info/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
 dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # clODE - an OpenCL based tool for solving ordinary differential equations (ODEs)
 
 [![Python](https://img.shields.io/pypi/pyversions/clode.svg)](https://badge.fury.io/py/clode)
-[![PyPI](https://badge.fury.io/py/clode.svg)](https://badge.fury.io/py/tensorflow)
+[![PyPI version](https://badge.fury.io/py/clode.svg)](https://badge.fury.io/py/clode)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patrickfletcher/clODE/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patrickfletcher/clODE)
 ![Windows](https://github.com/patrickfletcher/clODE/actions/workflows/bazel_build_windows.yml/badge.svg)
 ![Mac](https://github.com/patrickfletcher/clODE/actions/workflows/bazel_test_mac.yml/badge.svg) 

--- a/clode/python/__init__.py
+++ b/clode/python/__init__.py
@@ -16,4 +16,4 @@ from .stepper import Stepper
 from .trajectory import CLODETrajectory
 from .xpp_parser import convert_xpp_file, format_opencl_rhs, read_ode_parameters
 
-__version__ = "0.5.2"
+__version__ = "0.6.0"

--- a/clode/python/features.py
+++ b/clode/python/features.py
@@ -318,11 +318,10 @@ class CLODEFeatures:
             self._features.features(initialize_observer)
         else:
             self._features.features()
-        self._result_features = self._features.get_f()
-        self._num_result_features = self._features.get_n_features()
-        self._final_state = self._features.get_xf()
 
     def get_observer_results(self):
+        self._result_features = self._features.get_f()
+        self._num_result_features = self._features.get_n_features()
         return ObserverOutput(
             self._op,
             np.array(self._result_features),
@@ -333,6 +332,7 @@ class CLODEFeatures:
         )
 
     def get_final_state(self):
+        self._final_state = self._features.get_xf()
         final_state = np.array(self._final_state)
         return final_state.reshape(
             (len(self.vars), len(final_state) // len(self.vars))

--- a/clode/python/observer.py
+++ b/clode/python/observer.py
@@ -17,7 +17,9 @@ class Observer(Enum):
     neighbourhood_2 = "nhood2"
     threshold_2 = "thresh2"
 
-
+# may want other functionality here.
+# - full feature matrix, with names (pandas?)
+# - separate diagnostics (period count, step count, min dt, max dt , ...), summarize on print along with observer info/pars?
 class ObserverOutput:
     def __init__(
         self,

--- a/clode/python/trajectory.py
+++ b/clode/python/trajectory.py
@@ -43,10 +43,12 @@ class CLODETrajectory:
         self._data = None
         self._output_trajectories = None
         self._time_steps = None
+        self._output_time_steps = None
         self._number_of_simulations = None
         self._initial_conditions = None
         self._var_values = None
         self._n_stored = None
+        self._max_store = max_store
         if aux is None:
             aux = []
 
@@ -103,6 +105,7 @@ class CLODETrajectory:
             )
 
         self._data = None
+        self._time_steps = None
         self._number_of_simulations = parameters.shape[0]
 
         if tspan is not None:
@@ -156,32 +159,37 @@ class CLODETrajectory:
     def trajectory(self):
         self._trajectory.trajectory()
         self._n_stored = self._trajectory.get_n_stored()
-        self._time_steps = self._trajectory.get_t()
+        self._output_time_steps = self._trajectory.get_t()
         self._output_trajectories = self._trajectory.get_x()
         self._initial_conditions = self._trajectory.get_x0()
 
-    def get_time_steps(self):
-        return np.array(self._time_steps[: self._n_stored[0]])
-
-    def get_trajectory(self, simulation_id: int = 0):
-        # TODO: simulation id not implemented?
-        if simulation_id >= self._number_of_simulations:
-            raise ValueError(
-                f"Only {self._number_of_simulations} simulations were run, "
-                + f"simulation id {simulation_id} not valid"
-            )
-        if self._data is not None:
-            return self._data
-
-        n_stored = self._n_stored[simulation_id]
-
-        if n_stored == 0:
+    def get_trajectory(self):
+        # For now just return all the data.
+        # if simulation_id is not None and simulation_id >= self._number_of_simulations:
+        #     raise ValueError(
+        #         f"Only {self._number_of_simulations} simulations were run, "
+        #         + f"simulation id {simulation_id} not valid"
+        #     )
+        
+        if self._time_steps is not None and self._data is not None:
+            return self._time_steps, self._data, self._n_stored
+        
+        max_stored = max(self._n_stored)
+        if max_stored == 0:
             return np.array()
+        
+        # time_steps has one column per simulation (to support adaptive steppers)
+        shape = (self._number_of_simulations, self._max_store)
+        arr = np.array(self._output_time_steps[: np.prod(shape)])
+        self._time_steps = arr.reshape(shape, order="F").transpose((1, 0))
+        self._time_steps = self._time_steps[: max_stored, :]
 
-        shape = (self._number_of_simulations, len(self.vars), n_stored)
+        shape = (self._number_of_simulations, len(self.vars), self._max_store)
         arr = np.array(self._output_trajectories[: np.prod(shape)])
-        self._data = arr.reshape(shape, order="F").transpose((0, 2, 1))
-        return self._data
+        self._data = arr.reshape(shape, order="F").transpose((2, 1, 0))
+        self._data = self._data[: max_stored, :, :]
+
+        return self._time_steps, self._data, self._n_stored
 
     def print_devices(self) -> None:
         self._runtime.print_devices()

--- a/clode/python/trajectory.py
+++ b/clode/python/trajectory.py
@@ -158,10 +158,6 @@ class CLODETrajectory:
 
     def trajectory(self):
         self._trajectory.trajectory()
-        self._n_stored = self._trajectory.get_n_stored()
-        self._output_time_steps = self._trajectory.get_t()
-        self._output_trajectories = self._trajectory.get_x()
-        self._initial_conditions = self._trajectory.get_x0()
 
     def get_trajectory(self):
         # For now just return all the data.
@@ -170,6 +166,9 @@ class CLODETrajectory:
         #         f"Only {self._number_of_simulations} simulations were run, "
         #         + f"simulation id {simulation_id} not valid"
         #     )
+        self._n_stored = self._trajectory.get_n_stored()
+        self._output_time_steps = self._trajectory.get_t()
+        self._output_trajectories = self._trajectory.get_x()
         
         if self._time_steps is not None and self._data is not None:
             return self._time_steps, self._data, self._n_stored
@@ -190,6 +189,13 @@ class CLODETrajectory:
         self._data = self._data[: max_stored, :, :]
 
         return self._time_steps, self._data, self._n_stored
+
+    def get_final_state(self):
+        self._final_state = self._features.get_xf()
+        final_state = np.array(self._final_state)
+        return final_state.reshape(
+            (len(self.vars), len(final_state) // len(self.vars))
+        ).transpose()
 
     def print_devices(self) -> None:
         self._runtime.print_devices()

--- a/docs/feature_extraction.md
+++ b/docs/feature_extraction.md
@@ -1,5 +1,7 @@
 # Feature extraction
 
+...Under Construction...
+
 CLODE can simulate a large number of ODEs simultaneously using OpenCL.
 To keep memory usage low, CLODE extracts features on-the-fly
 using configurable observers. These observers are written in OpenCL

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -128,14 +128,14 @@ integrator.transient()
 integrator.trajectory()
 
 # get the results, and plot
-T, X, n_stored = integrator.get_trajectory()
+trajectories = integrator.get_trajectory()
 
 # plot
 varix = 0
 fig, ax = plt.subplots(4, 1, sharex=True, sharey=True)
 
-for i in range(nTraj):
-    ax[i].plot(T[: n_stored[i], i], X[: n_stored[i], varix, i])
+for i, trajectory in enumerate(trajectories):
+    ax[i].plot(trajectory["t"], trajectory["X"][:, varix])
 
 ax[1].set_ylabel(var_names[varix])
 ax[-1].set_xlabel('time')

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -44,12 +44,13 @@ void getRHS(const realtype t,
 
 Note that this is a simple C-language function. The ```realtype``` type declaration is a macro that will expand to ```float``` or ```double```, depending on our choice of single or double precision, which defaults to single precision.  Save this function in a file called ```van_der_pol_oscillator.cl```
 
-This function supports additional use cases not used in this example: ```t``` for time-dependent ODE terms (non-autonomous systems), ```aux``` for auxiliary readout variables, and stochastic terms via ```w```, which provides Wiener variables ($w \sim Normal \; (0,dt)$). Finally, one can also declare other simple C functions in the same file before ```getRHS``, and use them inside getRHS. For further example use cases, see [TODO]
+This function supports additional use cases not used in this example: ```t``` for time-dependent ODE terms (non-autonomous systems), ```aux``` for auxiliary readout variables, and stochastic terms via ```w```, which provides Wiener variables ($w \sim Normal \; (0,dt)$). If needed, one can also declare additional plain C-languange functions in the same file, preceding ```getRHS``, and use them inside getRHS.
 
 Next we will use a python script to define our parameters and set up the numerical simulation. Here we use clODE's feature detection mode - several features of the ODE solution, including the period of oscillation, will be measured "on the fly", without storing the trajectory itself.
 
 ```python
 import clode
+from clode import Stepper, Observer
 import numpy as np
 
 # time span for our simulation
@@ -60,23 +61,22 @@ integrator = clode.CLODEFeatures(
     src_file="van_der_pol_oscillator.cl", # This is your source file. 
     variable_names=["x", "y"],            # names for our variables
     parameter_names=["mu"],               # name for our parameters
-    num_noise=1,                          # Number of Weiner noise variables
-    observer=clode.Observer.threshold_2,  # Choose an observer
-    stepper=clode.Stepper.dormand_prince, # Choose a stepper
+    observer=Observer.threshold_2,  # Choose an observer
+    stepper=Stepper.rk4, # Choose a stepper
     tspan=tspan,
 )
 
 # Define parameter values of interest (only a few for demonstration)
-parameters = [-1, 0, 0.01, 0.1, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0]
+mu = [0.01, 0.5, 2.0, 4.0]
 
 # array format as expected internally - see implementation details
-pars_v = np.array([[par] for par in parameters])
+P0 = np.array([[u] for u in mu])
 
 # create initial conditions for each ODE instance
-x0 = np.tile([1, 1], (len(parameters), 1))
+x0 = np.tile([1, 1], (len(mu), 1))
 
 # send the data to the OpenCL device
-integrator.initialize(x0, pars_v)
+integrator.initialize(x0, P0)
 
 # Run the simulation for tspan time, storing only the final state.
 # Useful for integrating past transient behavior
@@ -92,6 +92,56 @@ print(observer_output.get_var_mean("period"))
 
 For more details, see the API reference [TODO]
 
+## Trajectories
+
+We can also compute and store full trajectories in parallel. This requires significantly more memory, though, but is important for validating the above feature results.  Using the same example, we next compute and plot a few examples trajectories.
+
+```python
+import clode
+from clode import Stepper, Observer
+import numpy as np
+import matplotlib.plt as plt
+
+# time span for our simulation
+tspan = (0.0, 1000.0)
+
+# Create the clODE trajectory solver
+integrator = clode.CLODETrajectory(
+    src_file="van_der_pol_oscillator.cl", # This is your source file. 
+    variable_names=["x", "y"],            # names for our variables
+    parameter_names=["mu"],               # name for our parameters
+    stepper=Stepper.rk4, # Choose a stepper
+    tspan=tspan,
+)
+
+# send the data to the OpenCL device
+integrator.initialize(x0, pars_v)
+
+# send the data to the OpenCL device
+integrator.initialize(x0, P0)
+
+# Run the simulation for tspan time, storing only the final state.
+# Useful for integrating past transient behavior
+integrator.transient()
+
+# Continue the simulation, now storing the trajectories
+integrator.trajectory()
+
+# get the results, and plot
+T, X, n_stored = integrator.get_trajectory()
+
+# plot
+varix = 0
+fig, ax = plt.subplots(4, 1, sharex=True, sharey=True)
+
+for i in range(nTraj):
+    ax[i].plot(T[: n_stored[i], i], X[: n_stored[i], varix, i])
+
+ax[1].set_ylabel(var_names[varix])
+ax[-1].set_xlabel('time')
+plt.show()
+```
+
 ## Implementation details
 
 The Python library wraps a CPP library, clode_cpp_wrapper.[so|dll]
@@ -100,6 +150,3 @@ by columns, i.e. if your variables are a, b and c,
 the CPP library expects data in the format [aaaabbbbcccc].
 The Python library expects data in the format
 [[a, b, c], [a, b, c], [a, b, c], ...]
-
-Note: There is a bug in the noise generation. It is currently not possible to
-set the number of noise variables to 0. Set to 1 or more.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -49,15 +49,14 @@ This function supports additional use cases not used in this example: ```t``` fo
 Next we will use a python script to define our parameters and set up the numerical simulation. Here we use clODE's feature detection mode - several features of the ODE solution, including the period of oscillation, will be measured "on the fly", without storing the trajectory itself.
 
 ```python
-import clode
-from clode import Stepper, Observer
+from clode import Stepper, Observer, CLODEFeatures
 import numpy as np
 
 # time span for our simulation
 tspan = (0.0, 1000.0)
 
 # Create the clODE feature extractor
-integrator = clode.CLODEFeatures(
+integrator = CLODEFeatures(
     src_file="van_der_pol_oscillator.cl", # This is your source file. 
     variable_names=["x", "y"],            # names for our variables
     parameter_names=["mu"],               # name for our parameters
@@ -94,28 +93,20 @@ For more details, see the API reference [TODO]
 
 ## Trajectories
 
-We can also compute and store full trajectories in parallel. This requires significantly more memory, though, but is important for validating the above feature results.  Using the same example, we next compute and plot a few examples trajectories.
+We can also compute and store full trajectories in parallel. This requires significantly more memory, though, but is important for validating the above feature results.  Continuing the example above, we next compute and plot the trajectories for the four parameters specified.
 
 ```python
-import clode
-from clode import Stepper, Observer
-import numpy as np
+from clode import CLODETrajectory
 import matplotlib.plt as plt
 
-# time span for our simulation
-tspan = (0.0, 1000.0)
-
 # Create the clODE trajectory solver
-integrator = clode.CLODETrajectory(
+integrator = CLODETrajectory(
     src_file="van_der_pol_oscillator.cl", # This is your source file. 
     variable_names=["x", "y"],            # names for our variables
     parameter_names=["mu"],               # name for our parameters
     stepper=Stepper.rk4, # Choose a stepper
     tspan=tspan,
 )
-
-# send the data to the OpenCL device
-integrator.initialize(x0, pars_v)
 
 # send the data to the OpenCL device
 integrator.initialize(x0, P0)
@@ -137,7 +128,7 @@ fig, ax = plt.subplots(4, 1, sharex=True, sharey=True)
 for i, trajectory in enumerate(trajectories):
     ax[i].plot(trajectory["t"], trajectory["X"][:, varix])
 
-ax[1].set_ylabel(var_names[varix])
+ax[1].set_ylabel('x')
 ax[-1].set_xlabel('time')
 plt.show()
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,46 @@
 # Introduction
 
-## C++
+## Python
+
+Pre-build binaries are provided via PyPI for Python 3.8-3.12 on MacOS and Windows, which can be installed simply using pip:
+```
+    pip install clode
+```
+An OpenCL runtime for your device is requires - often included as part of GPU drivers (AMD APP SDK, Intel OpenCL SDK, NVIDIA CUDA, etc.)
+
+## Installation from source
+
+To install the Python library from source, you will need the following dependencies:
+
+* A C++ compiler (GCC, Clang, MSVC, etc.)
+* Python 3.8 or later
+* An OpenCL runtime (AMD APP SDK, Intel OpenCL SDK, NVIDIA CUDA, etc.)
+
+You can then install the Python library using pip:
+
+```
+    pip install clode
+```
+
+This will download Bazel to your machine (using Bazelisk)
+and build the C++ libraries. It will then install the Python library.
+
+### Windows
+
+On Windows, prior to installing via pip you will need the following dependencies in addition to those listed above:
+
+* The MSVC C++ compiler (e.g., Visual Studio Community installed to default path)
+* MSYS2 (add msys64/usr/bin to path)
+
+Bazel will use MSVC to build the C++ libraries.
+Further, Bazel will include the OpenCL SDK in the build.
+This means that you do not need to install the OpenCL SDK separately.
+
+Should you wish to change this behaviour, you can modify the
+library inside bazel/external/opencl_windows.BUILD and
+bazel/repository_locations.bzl.
+
+## C++ stand-alone source installation
 
 To install the C++ library, you will need the following dependencies:
 
@@ -20,38 +60,6 @@ There are three libraries that will be built:
 * libclode_trajectory.a: The trajectory extraction library
 * libopencl_resources.a: The OpenCL resources library (to find your OpenCL runtime)
 
-## Python
-
-To install the Python library, you will need the following dependencies:
-
-* A C++ compiler (GCC, Clang, MSVC, etc.)
-* Python 3.8 or later
-* An OpenCL runtime (AMD APP SDK, Intel OpenCL SDK, NVIDIA CUDA, etc.)
-
-You can install the Python library using pip:
-
-```
-    pip install clode
-```
-
-This will download Bazel to your machine (using Bazelisk)
-and build the C++ libraries. It will then install the Python library.
-
-## Windows
-
-On Windows, prior to installing via pip you will need the following dependencies in addition to those listed above:
-
-* The MSVC C++ compiler (e.g., Visual Studio Community installed to default path)
-* MSYS2 (add msys64/usr/bin to path)
-
-Bazel will use MSVC to build the C++ libraries.
-Further, Bazel will include the OpenCL SDK in the build.
-This means that you do not need to install the OpenCL SDK separately.
-
-Should you wish to change this behaviour, you can modify the
-library inside bazel/external/opencl_windows.BUILD and
-bazel/repository_locations.bzl.
-
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](../LICENSE) file for details
@@ -61,5 +69,5 @@ This project is licensed under the MIT License - see the [LICENSE](../LICENSE) f
 To verify that the installation was successful, you can run the following command:
 
 ```
-python -c "import clode; print(clode.print_opencl())"
+python -c "from clode.runtime import query_opencl; print(query_opencl())"
 ```

--- a/docs/matlab.md
+++ b/docs/matlab.md
@@ -1,5 +1,11 @@
 # clODE Matlab interface
 
+## Note: currently unmaintained
+
+The Matlab interface will migrate to direct calls to the python version from Matlab.
+
+## Overview
+
 clODE solves many instances of the same ODE system given different input paramter values and/or initial conditions.
 
 This document describes the Matlab MEX-file interface provided for running clODE from within Matlab.

--- a/docs/trajectory_simulation.md
+++ b/docs/trajectory_simulation.md
@@ -1,5 +1,7 @@
 # Trajectory simulation
 
+...Under Construction...
+
 CLODE can simulate ODE trajectories using the CLODETrajectory class.
 
 ## Example

--- a/test/test_ornl_thompson_a1.py
+++ b/test/test_ornl_thompson_a1.py
@@ -44,7 +44,7 @@ def test_ornl_thompson_a1():
 
     time_steps, output_trajectory, n_stored = integrator.get_trajectory()
     time_steps = time_steps[: n_stored[0], 0]
-    output_trajectory = output_trajectory[: n_stored[0], 0]
+    output_trajectory = output_trajectory[: n_stored[0], :, 0]
 
     for tt, (y1, y2) in zip(time_steps, output_trajectory):
         expected_y1, expected_y2 = ornl_thompson_a1_exact(tt)

--- a/test/test_ornl_thompson_a1.py
+++ b/test/test_ornl_thompson_a1.py
@@ -42,8 +42,9 @@ def test_ornl_thompson_a1():
 
     integrator.trajectory()
 
-    time_steps = integrator.get_time_steps()
-    output_trajectory = integrator.get_trajectory()[0]
+    time_steps, output_trajectory, n_stored = integrator.get_trajectory()
+    time_steps = time_steps[: n_stored[0], 0]
+    output_trajectory = output_trajectory[: n_stored[0], 0]
 
     for tt, (y1, y2) in zip(time_steps, output_trajectory):
         expected_y1, expected_y2 = ornl_thompson_a1_exact(tt)

--- a/test/test_ornl_thompson_a1.py
+++ b/test/test_ornl_thompson_a1.py
@@ -42,9 +42,9 @@ def test_ornl_thompson_a1():
 
     integrator.trajectory()
 
-    time_steps, output_trajectory, n_stored = integrator.get_trajectory()
-    time_steps = time_steps[: n_stored[0], 0]
-    output_trajectory = output_trajectory[: n_stored[0], :, 0]
+    trajectories = integrator.get_trajectory() 
+    time_steps = trajectories[0]["t"]
+    output_trajectory = trajectories[0]["X"]
 
     for tt, (y1, y2) in zip(time_steps, output_trajectory):
         expected_y1, expected_y2 = ornl_thompson_a1_exact(tt)


### PR DESCRIPTION
For now - trajectories returned as a list of dicts {t, X}. This is to support the case when adaptive time stepper is used, which results in a different number of timesteps per trajectory. I think this makes for a convenient (iterable) way to access trajectories, for example:

```python
trajectories = integrator.get_trajectory()

# plot
varix = 0
fig, ax = plt.subplots(4, 1, sharex=True, sharey=True)

for i, trajectory in enumerate(trajectories):
    ax[i].plot(trajectory["t"], trajectory["X"][:, varix])
```

Also here:
- the C++ "getters" should be run in corresponding python get functions. This ensures that 1) latest result is retrieved from the device, and 2) device --> host data transfers are minimized.

More generally, I am contemplating the overall API.  I'd like things to be simple to use and easy to interface with other tools. There are some aspects of the C++ layer that aren't yet exposed, and some repeated code. Probably a new PR's worth of changes. We can discuss...