### PR TITLE
Correct documentation links in 0.7

### DIFF
--- a/clode/__init__.py
+++ b/clode/__init__.py
@@ -77,7 +77,7 @@ from clode.solver import Simulator, Stepper
 from clode.trajectory import TrajectorySimulator
 from clode.xpp_parser import convert_xpp_file, format_opencl_rhs, read_ode_parameters
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 __all__ = [
     "TrajectorySimulator",

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,11 @@
 ![Mac](https://github.com/patrickfletcher/clODE/actions/workflows/bazel_test_mac.yml/badge.svg)
 ![Linux](https://github.com/patrickfletcher/clODE/actions/workflows/bazel_build_linux.yml/badge.svg)
 
+**`Documentation`** |
+------------------- |
+[![Documentation](https://img.shields.io/badge/api-reference-blue.svg)](https://patrickfletcher.github.io/clODE/) |
+
+
 clODE is an efficient computational tool designed for parallel solving
 of ordinary differential equation (ODE) ensembles using OpenCL.
 It lets users define their ODE system and the ensemble of parameter sets and initial conditions in Python.  By leveraging OpenCL, significant speedups can be obtained for this inherently parallel problem on any CPU, GPU, or other device with OpenCL support. Two primary modes of simulation are supported:
@@ -24,11 +29,11 @@ and bazelisk, and works on Linux, Windows, and MacOS platforms.
 
 ## Installation
 
-See [installation](install.md) for instructions on how to install CLODE.
+See [installation](https://patrickfletcher.github.io/clODE/install/) for instructions on how to install CLODE.
 
 ## Getting Started
 
-See [Getting Started](getting_started.md) for an example of clODE usage.
+See [Getting Started](https://patrickfletcher.github.io/clODE/getting_started/) for an example of clODE usage.
 
 ## Source
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,7 @@ requires = [
     "wheel",
     "setuptools_scm"
 ]
+
+[project.urls]
+Documentation = "https://patrickfletcher.github.io/clODE/"
+Repository = "https://github.com/patrickfletcher/clODE"


### PR DESCRIPTION
Some links were broken in pypi and the documentation wasn't explicitly linked in the readme.